### PR TITLE
feat: testutil makeblock

### DIFF
--- a/types/test_util.go
+++ b/types/test_util.go
@@ -9,6 +9,10 @@ import (
 	cmtversion "github.com/cometbft/cometbft/proto/tendermint/version"
 	"github.com/cometbft/cometbft/version"
 	"github.com/stretchr/testify/require"
+
+	// <sunrise-core>
+	"encoding/binary"
+	// <sunrise-core />
 )
 
 func MakeExtCommit(blockID BlockID, height int64, round int32,
@@ -107,13 +111,23 @@ func MakeVoteNoError(
 // computed from itself.
 // It populates the same set of fields validated by ValidateBasic.
 func MakeBlock(height int64, txs []Tx, lastCommit *Commit, evidence []Evidence) *Block {
+	// <sunrise-core>
+	txBytes := Txs(txs).ToSliceOfBytes()
+	txsWithoutInfoBytes, dataHash, squareSize, _ := ExtractInfoFromTxs(txBytes)
+	txsWithoutInfo := ToTxs(txsWithoutInfoBytes)
+	// </sunrise-core>
+
 	block := &Block{
 		Header: Header{
 			Version: cmtversion.Consensus{Block: version.BlockProtocol, App: 0},
 			Height:  height,
 		},
 		Data: Data{
-			Txs: txs,
+			// <sunrise-core>
+			Txs:        txsWithoutInfo,
+			SquareSize: squareSize,
+			hash:       dataHash,
+			// </sunrise-core>
 		},
 		Evidence:   EvidenceData{Evidence: evidence},
 		LastCommit: lastCommit,
@@ -121,3 +135,21 @@ func MakeBlock(height int64, txs []Tx, lastCommit *Commit, evidence []Evidence) 
 	block.fillHeader()
 	return block
 }
+
+// <sunrise-core>
+func ExtractInfoFromTxs(txsWithInfo [][]byte) (txs [][]byte, dataHash []byte, squareSize uint64, err error) {
+	length := len(txsWithInfo)
+	if length < 2 {
+		err = fmt.Errorf("txs must contain the data hash and the square size at the end, and its length must not be lower than 2")
+		return
+	}
+
+	txs = txsWithInfo[:length-2]
+	dataHash = txsWithInfo[length-2]
+	squareSizeBigEndian := txsWithInfo[length-1]
+	squareSize = binary.BigEndian.Uint64(squareSizeBigEndian)
+
+	return
+}
+
+// </sunrise-core>


### PR DESCRIPTION
same as #1

It will solve the block data problem
```
# sunrised q block --type=height 1
data:
  hash: null
  square_size: "0"
  txs:
  - PZa30jjn4EVvavjnzfCme9bPnCCJ7LVZxlncqh+IA1M=
  - AAAAAAAAAAE=
 ```