### PR TITLE
fix: RPC signed_block

### DIFF
--- a/inspect/rpc/rpc.go
+++ b/inspect/rpc/rpc.go
@@ -39,6 +39,7 @@ func Routes(cfg config.RPCConfig, s state.Store, bs state.BlockStore, txidx txin
 		"blockchain":       server.NewRPCFunc(env.BlockchainInfo, "minHeight,maxHeight"),
 		"consensus_params": server.NewRPCFunc(env.ConsensusParams, "height"),
 		"block":            server.NewRPCFunc(env.Block, "height"),
+		"signed_block":     server.NewRPCFunc(env.SignedBlock, "height"),
 		"block_by_hash":    server.NewRPCFunc(env.BlockByHash, "hash"),
 		"block_results":    server.NewRPCFunc(env.BlockResults, "height"),
 		"commit":           server.NewRPCFunc(env.Commit, "height"),


### PR DESCRIPTION
Fix RPC Error
```
2024-04-17T02:31:16.233+0900    ERROR   header/sync     sync/sync.go:227        syncing headers {"from": 2, "to": 33, "err": "fetching signed block at height 3 from core: error in json rpc client, with http response metadata: (Status: 200 OK, Protocol HTTP/1.1). RPC error -32601 - Method not found"}
```
<!--

Please add a reference to the issue that this PR addresses and indicate which
files are most critical to review. If it fully addresses a particular issue,
please include "Closes #XXX" (where "XXX" is the issue number).

If this PR is non-trivial/large/complex, please ensure that you have either
created an issue that the team's had a chance to respond to, or had some
discussion with the team prior to submitting substantial pull requests. The team
can be reached via GitHub Discussions or the Cosmos Network Discord server in
the #cometbft channel. GitHub Discussions is preferred over Discord as it
allows us to keep track of conversations topically.
https://github.com/cometbft/cometbft/discussions

If the work in this PR is not aligned with the team's current priorities, please
be advised that it may take some time before it is merged - especially if it has
not yet been discussed with the team.

See the project board for the team's current priorities:
https://github.com/orgs/cometbft/projects/1

-->

---

#### PR checklist

- [ ] Tests written/updated
- [ ] Changelog entry added in `.changelog` (we use [unclog](https://github.com/informalsystems/unclog) to manage our changelog)
- [ ] Updated relevant documentation (`docs/` or `spec/`) and code comments

